### PR TITLE
Support unicode using runes instead of bytes

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -5,15 +5,16 @@ import (
 )
 
 type Lexer struct {
-	input        string
+	//input        string
+	input        []rune
 	position     int
 	readPosition int
-	ch           byte
+	ch           rune
 }
 
 func NewLexer(input string) *Lexer {
-	l := &Lexer{input: input}
-	l.readChar()
+	l := &Lexer{input: []rune(input)}
+	l.readRune()
 	return l
 }
 
@@ -25,7 +26,7 @@ func (l *Lexer) NextToken() token.Token {
 	switch l.ch {
 	case '=':
 		if l.peekChar() == '=' {
-			l.readChar()
+			l.readRune()
 			tok = token.Token{Type: token.EQ, Literal: "=="}
 		} else {
 			tok = newToken(token.ASSIGN, l.ch)
@@ -52,7 +53,7 @@ func (l *Lexer) NextToken() token.Token {
 		tok = newToken(token.SLASH, l.ch)
 	case '!':
 		if l.peekChar() == '=' {
-			l.readChar()
+			l.readRune()
 			tok = token.Token{Type: token.NOT_EQ, Literal: "!="}
 		} else {
 			tok = newToken(token.BANG, l.ch)
@@ -80,15 +81,15 @@ func (l *Lexer) NextToken() token.Token {
 		}
 	}
 
-	l.readChar()
+	l.readRune()
 	return tok
 }
 
-func newToken(tokenType token.TokenType, ch byte) token.Token {
+func newToken(tokenType token.TokenType, ch rune) token.Token {
 	return token.Token{Type: tokenType, Literal: string(ch)}
 }
 
-func (l *Lexer) readChar() {
+func (l *Lexer) readRune() {
 	if l.readPosition >= len(l.input) {
 		l.ch = 0
 	} else {
@@ -98,7 +99,7 @@ func (l *Lexer) readChar() {
 	l.readPosition += 1
 }
 
-func (l *Lexer) peekChar() byte {
+func (l *Lexer) peekChar() rune {
 	if l.readPosition >= len(l.input) {
 		return 0
 	} else {
@@ -109,34 +110,34 @@ func (l *Lexer) peekChar() byte {
 func (l *Lexer) readIdentifier() string {
 	position := l.position
 	for isLetter(l.ch) {
-		l.readChar()
+		l.readRune()
 	}
-	return l.input[position:l.position]
+	return string(l.input[position:l.position])
 }
 
 func (l *Lexer) readNumber() string {
 	position := l.position
 	for isDigit(l.ch) {
-		l.readChar()
+		l.readRune()
 	}
 
-	return l.input[position:l.position]
+	return string(l.input[position:l.position])
 }
 
 func (l *Lexer) skipWhitespace() {
 	for isWhitespace(l.ch) {
-		l.readChar()
+		l.readRune()
 	}
 }
 
-func isLetter(ch byte) bool {
-	return 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch == '_'
+func isLetter(ch rune) bool {
+	return 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch == '_' || ch >= 128
 }
 
-func isDigit(ch byte) bool {
+func isDigit(ch rune) bool {
 	return '0' <= ch && ch <= '9'
 }
 
-func isWhitespace(ch byte) bool {
+func isWhitespace(ch rune) bool {
 	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r'
 }

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -159,3 +159,110 @@ func TestNextToken2(t *testing.T) {
 		}
 	}
 }
+
+func TestNextToken_UnicodeVariables(t *testing.T) {
+	input := `
+		let five = 5;
+		let år = 2023;
+		let número = 42;
+		let α = 1;
+		let β = 2;
+		let возраст = 25;
+		let 年齢 = 30;
+		let عمر = 27;
+		let 温度inCelsius = 25;
+		let 学生count = 30;
+		let 年龄 = 22;
+		let 🎉 = 10;
+	`
+
+	tests := []struct {
+		expectedType    token.TokenType
+		expectedLiteral string
+	}{
+		{token.LET, "let"},
+		{token.IDENT, "five"},
+		{token.ASSIGN, "="},
+		{token.INT, "5"},
+		{token.SEMICOLON, ";"},
+
+		{token.LET, "let"},
+		{token.IDENT, "år"},
+		{token.ASSIGN, "="},
+		{token.INT, "2023"},
+		{token.SEMICOLON, ";"},
+
+		{token.LET, "let"},
+		{token.IDENT, "número"},
+		{token.ASSIGN, "="},
+		{token.INT, "42"},
+		{token.SEMICOLON, ";"},
+
+		{token.LET, "let"},
+		{token.IDENT, "α"},
+		{token.ASSIGN, "="},
+		{token.INT, "1"},
+		{token.SEMICOLON, ";"},
+
+		{token.LET, "let"},
+		{token.IDENT, "β"},
+		{token.ASSIGN, "="},
+		{token.INT, "2"},
+		{token.SEMICOLON, ";"},
+
+		{token.LET, "let"},
+		{token.IDENT, "возраст"},
+		{token.ASSIGN, "="},
+		{token.INT, "25"},
+		{token.SEMICOLON, ";"},
+
+		{token.LET, "let"},
+		{token.IDENT, "年齢"},
+		{token.ASSIGN, "="},
+		{token.INT, "30"},
+		{token.SEMICOLON, ";"},
+
+		{token.LET, "let"},
+		{token.IDENT, "عمر"},
+		{token.ASSIGN, "="},
+		{token.INT, "27"},
+		{token.SEMICOLON, ";"},
+
+		{token.LET, "let"},
+		{token.IDENT, "温度inCelsius"},
+		{token.ASSIGN, "="},
+		{token.INT, "25"},
+		{token.SEMICOLON, ";"},
+
+		{token.LET, "let"},
+		{token.IDENT, "学生count"},
+		{token.ASSIGN, "="},
+		{token.INT, "30"},
+		{token.SEMICOLON, ";"},
+
+		{token.LET, "let"},
+		{token.IDENT, "年龄"},
+		{token.ASSIGN, "="},
+		{token.INT, "22"},
+		{token.SEMICOLON, ";"},
+
+		{token.LET, "let"},
+		{token.IDENT, "🎉"},
+		{token.ASSIGN, "="},
+		{token.INT, "10"},
+		{token.SEMICOLON, ";"},
+	}
+
+	l := NewLexer(input)
+
+	for i, tt := range tests {
+		tok := l.NextToken()
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong. expected=%q, got=%q", i, tt.expectedType, tok.Type)
+		}
+
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - tokentype wrong. expected=%q, got=%q", i, tt.expectedLiteral, tok.Literal)
+		}
+	}
+}


### PR DESCRIPTION
closes https://github.com/hlastras/monkeylang/issues/1

Implementation based on Golang runes. The input is converted to a list of runes, then iterate in the same way over it.

To detect if a rune is a letter, I use the same logic for ASCII runes (<128) and all runes with a value >= than 128 is consider a letter.